### PR TITLE
remove cypress

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,7 +12,6 @@
 module.exports = {
   extends: [
     "eslint:recommended",
-    "plugin:cypress/recommended",
     "plugin:@typescript-eslint/recommended",
     "plugin:@typescript-eslint/eslint-recommended",
     "eslint-config-prettier"


### PR DESCRIPTION
If cypress isn't used, we shouldn't be required to have eslint-plugin-cypress
<img width="1659" alt="Screen Shot 2022-03-16 at 9 03 24 AM" src="https://user-images.githubusercontent.com/8163241/158621224-0fd27d07-2c7d-4fa3-a113-358a79452ff2.png">
.